### PR TITLE
feat: display classroom

### DIFF
--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,0 +1,14 @@
+/** @type {import("prettier").Config} */
+export default {
+  tabWidth: 2,
+  useTabs: false,
+  plugins: ["prettier-plugin-astro"],
+  overrides: [
+    {
+      files: "*.astro",
+      options: {
+        parser: "astro",
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "devDependencies": {
     "@types/google.maps": "^3.54.0",
     "postcss-nesting": "^12.0.1",
+    "prettier": "^3.0.3",
+    "prettier-plugin-astro": "^0.12.1",
     "sass": "^1.63.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ specifiers:
   i18next: ^22.5.1
   i18next-fs-backend: ^2.1.5
   postcss-nesting: ^12.0.1
+  prettier: ^3.0.3
+  prettier-plugin-astro: ^0.12.1
   react: ^18.0.0
   react-dom: ^18.0.0
   sass: ^1.63.6
@@ -48,6 +50,8 @@ dependencies:
 devDependencies:
   '@types/google.maps': 3.54.0
   postcss-nesting: 12.0.1
+  prettier: 3.0.3
+  prettier-plugin-astro: 0.12.1
   sass: 1.66.1
 
 packages:
@@ -68,6 +72,10 @@ packages:
   /@astrojs/compiler/0.31.4:
     resolution: {integrity: sha512-6bBFeDTtPOn4jZaiD3p0f05MEGQL9pw2Zbfj546oFETNmjJFWO3nzHz6/m+P53calknCvyVzZ5YhoBLIvzn5iw==}
     dev: false
+
+  /@astrojs/compiler/1.8.2:
+    resolution: {integrity: sha512-o/ObKgtMzl8SlpIdzaxFnt7SATKPxu4oIP/1NL+HDJRzxfJcAkOTAb/ZKMRyULbz4q+1t2/DAebs2Z1QairkZw==}
+    dev: true
 
   /@astrojs/compiler/2.0.1:
     resolution: {integrity: sha512-DfBR7Cf+tOgQ4n7TIgTtU5x5SEA/08DNshpEPcT+91A0KbBlmUOYMBM/O6qAaHkmVo1KIoXQYhAmfdTT1zx9PQ==}
@@ -4639,6 +4647,15 @@ packages:
       which-pm: 2.0.0
     dev: false
 
+  /prettier-plugin-astro/0.12.1:
+    resolution: {integrity: sha512-1mlNIU/cV+25oB4z5wXzOz2fSDcawG3MsVUwgw2i8VSy7voLSENMSpR1juu3U5MAVUo3owuyax11QuylbpuqOQ==}
+    engines: {node: ^14.15.0 || >=16.0.0}
+    dependencies:
+      '@astrojs/compiler': 1.8.2
+      prettier: 3.0.3
+      sass-formatter: 0.7.8
+    dev: true
+
   /prettier-plugin-astro/0.7.2:
     resolution: {integrity: sha512-mmifnkG160BtC727gqoimoxnZT/dwr8ASxpoGGl6EHevhfblSOeu+pwH1LAm5Qu1MynizktztFujHHaijLCkww==}
     engines: {node: ^14.15.0 || >=16.0.0, pnpm: '>=7.14.0'}
@@ -4654,6 +4671,12 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: false
+
+  /prettier/3.0.3:
+    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /prismjs/1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
@@ -4964,7 +4987,6 @@ packages:
 
   /s.color/0.0.15:
     resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
-    dev: false
 
   /sade/1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -4985,7 +5007,6 @@ packages:
     resolution: {integrity: sha512-7fI2a8THglflhhYis7k06eUf92VQuJoXzEs2KRP0r1bluFxKFvLx0Ns7c478oYGM0fPfrr846ZRWVi2MAgHt9Q==}
     dependencies:
       suf-log: 2.5.3
-    dev: false
 
   /sass/1.66.1:
     resolution: {integrity: sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==}
@@ -5346,7 +5367,6 @@ packages:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
     dependencies:
       s.color: 0.0.15
-    dev: false
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}

--- a/src/components/AgendaIntermission.astro
+++ b/src/components/AgendaIntermission.astro
@@ -3,7 +3,7 @@ const { length, name } = Astro.props;
 ---
 
 <li class="w-full rounded-3xl bg-[#232323] mx-2 p-6">
-  <div class="flex justify-end">
+  <div class="flex justify-start pb-6">
     <span class="badge badge-secondary">
       {length}
     </span>

--- a/src/components/AgendaOverview.astro
+++ b/src/components/AgendaOverview.astro
@@ -13,7 +13,6 @@ type Props = {
 };
 
 const { events, isSpeakerPage } = Astro.props;
-
 ---
 
 {
@@ -36,7 +35,7 @@ const { events, isSpeakerPage } = Astro.props;
               "md:p-0 w-full inline-block overflow-hidden md:rounded-3xl md:bg-[#232323]",
               {
                 splide: hasMultipleEvents,
-              }
+              },
             )}
           >
             <div class={clsx({ splide__track: hasMultipleEvents })}>
@@ -76,45 +75,47 @@ const { events, isSpeakerPage } = Astro.props;
               </ul>
             </div>
             {hasMultipleEvents && (
-              <div class="flex md:mx-6 md:pb-5">
-                <div class="splide__arrows hidden md:block rounded-xl bg-[#323232] divide-x divide-dashed p-1 py-3">
-                  <button
-                    aria-label="Prev"
-                    class="splide__arrow--prev  p-2 px-4 text-2xl"
-                  >
-                    <svg
-                      width="10"
-                      height="13"
-                      viewBox="0 0 10 13"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
+              <>
+                <div class="flex md:mx-6 md:pb-5">
+                  <div class="splide__arrows hidden md:block rounded-xl bg-[#323232] divide-x divide-dashed p-1 py-3">
+                    <button
+                      aria-label="Prev"
+                      class="splide__arrow--prev  p-2 px-4 text-2xl"
                     >
-                      <path
-                        d="M8.75 7.16406L3.4375 12.4766C3.04688 12.8672 2.46094 12.8672 2.10938 12.4766L1.21094 11.6172C0.859375 11.2266 0.859375 10.6406 1.21094 10.2891L5 6.53906L1.21094 2.75C0.859375 2.39844 0.859375 1.8125 1.21094 1.42188L2.10938 0.523438C2.46094 0.171875 3.04688 0.171875 3.4375 0.523438L8.75 5.83594C9.10156 6.22656 9.10156 6.8125 8.75 7.16406Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    aria-label="Next"
-                    class="splide__arrow--next  p-2 px-4 text-2xl"
-                  >
-                    <svg
-                      width="10"
-                      height="13"
-                      viewBox="0 0 10 13"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
+                      <svg
+                        width="10"
+                        height="13"
+                        viewBox="0 0 10 13"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.75 7.16406L3.4375 12.4766C3.04688 12.8672 2.46094 12.8672 2.10938 12.4766L1.21094 11.6172C0.859375 11.2266 0.859375 10.6406 1.21094 10.2891L5 6.53906L1.21094 2.75C0.859375 2.39844 0.859375 1.8125 1.21094 1.42188L2.10938 0.523438C2.46094 0.171875 3.04688 0.171875 3.4375 0.523438L8.75 5.83594C9.10156 6.22656 9.10156 6.8125 8.75 7.16406Z"
+                          fill="white"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-label="Next"
+                      class="splide__arrow--next  p-2 px-4 text-2xl"
                     >
-                      <path
-                        d="M8.75 7.16406L3.4375 12.4766C3.04688 12.8672 2.46094 12.8672 2.10938 12.4766L1.21094 11.6172C0.859375 11.2266 0.859375 10.6406 1.21094 10.2891L5 6.53906L1.21094 2.75C0.859375 2.39844 0.859375 1.8125 1.21094 1.42188L2.10938 0.523438C2.46094 0.171875 3.04688 0.171875 3.4375 0.523438L8.75 5.83594C9.10156 6.22656 9.10156 6.8125 8.75 7.16406Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </button>
+                      <svg
+                        width="10"
+                        height="13"
+                        viewBox="0 0 10 13"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8.75 7.16406L3.4375 12.4766C3.04688 12.8672 2.46094 12.8672 2.10938 12.4766L1.21094 11.6172C0.859375 11.2266 0.859375 10.6406 1.21094 10.2891L5 6.53906L1.21094 2.75C0.859375 2.39844 0.859375 1.8125 1.21094 1.42188L2.10938 0.523438C2.46094 0.171875 3.04688 0.171875 3.4375 0.523438L8.75 5.83594C9.10156 6.22656 9.10156 6.8125 8.75 7.16406Z"
+                          fill="white"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <ul class="splide__pagination md:hidden"></ul>
+                <ul class="splide__pagination md:hidden" />
+              </>
             )}
           </div>
         </div>
@@ -139,7 +140,7 @@ const { events, isSpeakerPage } = Astro.props;
 
   document.addEventListener("DOMContentLoaded", (event) => {
     const elms = document.getElementsByClassName(
-      "splide"
+      "splide",
     ) as HTMLCollectionOf<HTMLElement>;
 
     for (var i = 0; i < elms.length; i++) {
@@ -152,17 +153,31 @@ const { events, isSpeakerPage } = Astro.props;
           pagination: true,
         });
 
+        splide.on("active", (evt) => {
+          if (window.innerHeight < evt.slide.offsetHeight + 100) {
+            const { x, y } = evt.slide.getBoundingClientRect();
+
+            window.scrollTo({
+              left: x,
+              behavior: "smooth",
+              top: y + window.scrollY - 100,
+            });
+          }
+        });
+
         splide.mount();
       }
     }
   });
 </script>
+
 <style>
   [class^="splide"]:disabled svg {
     opacity: 0.3;
     cursor: not-allowed;
   }
 </style>
+
 <style is:global>
   .splide__pagination {
     gap: 0.1rem !important;
@@ -177,7 +192,6 @@ const { events, isSpeakerPage } = Astro.props;
     border-radius: 3px !important;
     transform: none !important;
   }
-
 
   .splide__pagination__page.is-active {
     background-color: #f6f6f6 !important;

--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -23,18 +23,19 @@ const { name, language, speaker, length, multiple, room, tags, isSpeakerPage } =
 
 <li
   class={clsx("flex flex-col md:flex-row gap-6 overflow-hidden w-full", {
-    "splide__slide md:m-6 mx-2 md:max-w-[90%] relative": multiple,
+    "splide__slide md:m-6 mx-2 md:max-w-[90%] relative scroll-m-[96px]":
+      multiple,
     "px-2 md:px-0": !multiple,
   })}
 >
   <div
-    class={clsx("rounded-3xl flex flex-col w-full bg-[#232323]", {
+    class={clsx("rounded-3xl flex flex-col w-full bg-[#232323] h-full", {
       "md:bg-[#2E2E2E]": multiple,
     })}
   >
     <div class="h-full">
       <div class="p-6">
-        <div class="flex justify-start pb-6 gap-2">
+        <div class="flex justify-start pb-3 gap-2 flex-wrap">
           <span class="badge badge-secondary">
             {length}
           </span>
@@ -42,10 +43,10 @@ const { name, language, speaker, length, multiple, room, tags, isSpeakerPage } =
           <span class="badge badge-secondary">
             {language}
           </span>
-          <span
-            class="badge badge-outline badge-lg ml-auto"
-          >
-            {room}
+        </div>
+        <div class="pb-6">
+          <span class="text-primary-content font-light">
+            🚪 {room}
           </span>
         </div>
         <h2 class="text-2xl md:text-4xl font-black">{name}</h2>


### PR DESCRIPTION
Sistema il modo in cui vengono disposte le card: prendono tutta la lunghezza disponibile (per evitare che ci sia il vuoto tra un evento con descrizione lunghe e meno lunghe) e torna su in automatico se siamo in mobile (migliorando l'esperienza utente risparmiandogli di dover scrollare ogni volta).

![preview](https://github.com/gdgpescara/hedwig/assets/7157155/a984f149-a8bb-4e12-991e-a77093841f77)

Aggiunto il signifier della porta per indicare la stanza, se non è abbastanza torniamo all'idea precedente e aggiungiamo "room"
